### PR TITLE
Center scan UI content

### DIFF
--- a/app/src/main/java/com/example/tripwire/ui/ScamScanScreen.kt
+++ b/app/src/main/java/com/example/tripwire/ui/ScamScanScreen.kt
@@ -15,48 +15,59 @@ fun ScamScanScreen(viewModel: ScamScanViewModel) {
     val input by viewModel.input.collectAsState()
     val useGenAI by viewModel.useGenAI.collectAsState()
 
-    Column(Modifier.padding(16.dp)) {
-        OutlinedTextField(
-            value = input,
-            onValueChange = { viewModel.input.value = it },
-            label = { Text("Paste text message") },
-            modifier = Modifier.fillMaxWidth()
-        )
-
-        Spacer(Modifier.height(12.dp))
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Button(
-                onClick = { viewModel.classify() },
-                enabled = uiState !is UiState.Loading
-            ) { Text(if (uiState is UiState.Loading) "Classifying…" else "Classify") }
-
-            Spacer(Modifier.width(16.dp))
-
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(
-                    checked = useGenAI,
-                    onCheckedChange = viewModel::setUseGenAI
-                )
-                Text("Use GenAI")
-            }
-        }
-
-        Spacer(Modifier.height(16.dp))
-
-        when (uiState) {
-            is UiState.Error -> Text(
-                text = (uiState as UiState.Error).message,
-                color = MaterialTheme.colorScheme.error
+            OutlinedTextField(
+                value = input,
+                onValueChange = { viewModel.input.value = it },
+                label = { Text("Paste text message") },
+                modifier = Modifier.fillMaxWidth()
             )
-            is UiState.Success -> {
-                val s = uiState as UiState.Success
-                Text("Verdict: ${s.label} • ${s.raw}")
+
+            Spacer(Modifier.height(12.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(
+                    onClick = { viewModel.classify() },
+                    enabled = uiState !is UiState.Loading
+                ) { Text(if (uiState is UiState.Loading) "Classifying…" else "Classify") }
+
+                Spacer(Modifier.width(16.dp))
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = useGenAI,
+                        onCheckedChange = viewModel::setUseGenAI
+                    )
+                    Text("Use GenAI")
+                }
             }
-            else -> {}
+
+            Spacer(Modifier.height(16.dp))
+
+            when (uiState) {
+                is UiState.Error -> Text(
+                    text = (uiState as UiState.Error).message,
+                    color = MaterialTheme.colorScheme.error
+                )
+                is UiState.Success -> {
+                    val s = uiState as UiState.Success
+                    Text("Verdict: ${s.label} • ${s.raw}")
+                }
+                else -> {}
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- center the scan screen content vertically to keep it away from the OS status bar
- align the action row so the classify button and GenAI toggle sit in the middle of the display

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc36ea28008330be43b47c2c50bf24